### PR TITLE
First steps in code splitting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5"
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,15 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
+import Config from "./Config";
 
-import Tablet from "Tablet/MainScreen";
-import Phone from "Phone/MainScreen";
-import Config from "Config";
+import "bootstrap/dist/css/bootstrap.min.css";
+import "bootswatch/dist/slate/bootstrap.min.css";
+import "bootstrap-slider/dist/css/bootstrap-slider.css";
+import "react-bootstrap-toggle/dist/bootstrap2-toggle.css";
 
-const App = () => {
+const Tablet = lazy(() => import("./Tablet/MainScreen" /* webpackChunkName: "tablet", webpackPreload: true  */));
+const Phone = lazy(() => import("./Phone/MainScreen" /* webpackChunkName: "phone", webpackPreload: true  */));
+
+const Platform = () => {
   if (Config.bowser.platform.type === "mobile") {
     setTimeout(async () => {
       try {
@@ -18,4 +23,11 @@ const App = () => {
   }
   return <Tablet />;
 };
+
+const App = () => (
+  <Suspense fallback={<div className="loader" />}>
+    <Platform />
+  </Suspense>
+);
+
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -6,8 +6,12 @@ import "bootswatch/dist/slate/bootstrap.min.css";
 import "bootstrap-slider/dist/css/bootstrap-slider.css";
 import "react-bootstrap-toggle/dist/bootstrap2-toggle.css";
 
-const Tablet = lazy(() => import("./Tablet/MainScreen" /* webpackChunkName: "tablet", webpackPreload: true  */));
-const Phone = lazy(() => import("./Phone/MainScreen" /* webpackChunkName: "phone", webpackPreload: true  */));
+const Tablet = lazy(() =>
+  import("./Tablet/MainScreen" /* webpackChunkName: "tablet", webpackPrefetch: true  */)
+);
+const Phone = lazy(() =>
+  import("./Phone/MainScreen" /* webpackChunkName: "phone", webpackPrefetch: true  */)
+);
 
 const Platform = () => {
   if (Config.bowser.platform.type === "mobile") {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ if (!mobile && meta && Config.bowser.platform.model !== "iPad") {
 //meta.setAttribute("content", "height=" + window.innerHeight);
 
 MQTT.once("connect", () => {
-  import("./App" /* webpackChunkName: "reel", webpackPreload: true */)
+  import("./App" /* webpackChunkName: "robodomo", webpackPreload: true */)
     .then(mod => mod.default)
     .then(App => {
       ReactDOM.render(<App />, document.getElementById("root"));

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
-import MQTT from "lib/MQTT";
+// import MQTT from 'lib/MQTT';
 
-import "bootstrap/dist/css/bootstrap.min.css";
-import "bootswatch/dist/slate/bootstrap.min.css";
-import "bootstrap-slider/dist/css/bootstrap-slider.css";
-import "react-bootstrap-toggle/dist/bootstrap2-toggle.css";
+import Config from "./Config";
 
-import Config from "Config";
-
+/* prettier-ignore */
 console.log(
   "platform",
   Config.bowser,
@@ -35,13 +30,14 @@ if (!mobile && meta && Config.bowser.platform.model !== "iPad") {
 //outer.style.height = "100%";
 //meta.setAttribute("content", "height=" + window.innerHeight);
 
-MQTT.once("connect", () => {
-  ReactDOM.render(
-    <App style={{ height: "100%" }} />,
-    document.getElementById("root")
-  );
-});
-MQTT.connect();
+// MQTT.once('connect', () => {
+import("./App" /* webpackChunkName: "reel", webpackPreload: true */)
+  .then(mod => mod.default)
+  .then(App => {
+    ReactDOM.render(<App />, document.getElementById("root"));
+  });
+// });
+// MQTT.connect();
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import * as serviceWorker from "./serviceWorker";
-
-// import MQTT from 'lib/MQTT';
-
+import MQTT from "./lib/MQTT";
 import Config from "./Config";
 
 /* prettier-ignore */
@@ -30,14 +28,14 @@ if (!mobile && meta && Config.bowser.platform.model !== "iPad") {
 //outer.style.height = "100%";
 //meta.setAttribute("content", "height=" + window.innerHeight);
 
-// MQTT.once('connect', () => {
-import("./App" /* webpackChunkName: "reel", webpackPreload: true */)
-  .then(mod => mod.default)
-  .then(App => {
-    ReactDOM.render(<App />, document.getElementById("root"));
-  });
-// });
-// MQTT.connect();
+MQTT.once("connect", () => {
+  import("./App" /* webpackChunkName: "reel", webpackPreload: true */)
+    .then(mod => mod.default)
+    .then(App => {
+      ReactDOM.render(<App />, document.getElementById("root"));
+    });
+});
+MQTT.connect();
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Saves 32.79 KB of compressed app size. Only the JS required for the platform is loaded (Tablet or Phone) for an even smaller footprint

Initial `.prettierrc` added that roughly matches the existing coding style. Trailing commas are the only real difference as far as I could see for now