### PR TITLE
undo useEffect arrays... we need to investigate better practice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6362,18 +6362,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
-    "history": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
-      "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6383,11 +6371,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -8349,9 +8332,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10067,21 +10050,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
-    "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
-    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -11781,53 +11749,6 @@
         }
       }
     },
-    "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
-      "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
-      "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "react-scripts": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.1.tgz",
@@ -12308,11 +12229,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-    },
-    "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14188,11 +14104,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/src/Phone/Autelis/AutelisTab.js
+++ b/src/Phone/Autelis/AutelisTab.js
@@ -145,7 +145,8 @@ const AutelisTab = () => {
       MQTT.unsubscribe(weather_topic + "now", handleWeatherChange);
       MQTT.unsubscribe(weather_topic + "display_city", handleWeatherChange);
     };
-  }, [backward, forward, status_topic, topics, weather_topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Send message to control a device

--- a/src/Phone/Dashboard/DimmerItem.js
+++ b/src/Phone/Dashboard/DimmerItem.js
@@ -37,7 +37,8 @@ const DimmerItem = ({ name }) => {
       MQTT.unsubscribe(status_topic + "switch", onStateChange);
       MQTT.unsubscribe(status_topic + "level", onStateChange);
     };
-  }, [status_topic, status_topic_length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onClick = e => {
     e.stopPropagation();

--- a/src/Phone/Dashboard/TheaterItem.js
+++ b/src/Phone/Dashboard/TheaterItem.js
@@ -20,33 +20,6 @@ const TheaterItem = ({ title }) => {
   const tivo = useRef(null);
   const denon = useRef(null);
 
-  const findTheater = () => {
-    for (const t of Config.theaters) {
-      if (t.title === title) {
-        return t;
-      }
-    }
-    return null;
-  };
-  const def = findTheater();
-  if (!def) {
-    return <div>Config.js error: Theater {title} not found</div>;
-  }
-
-  const devices = def.devices || [],
-    deviceMap = {};
-
-  for (const device of devices) {
-    deviceMap[device.type] = device;
-  }
-
-  const activities = def.activities || [],
-    activitiesMap = {};
-
-  for (const activity of activities) {
-    activitiesMap[activity.name] = activities;
-  }
-
   let tvType = "unknown";
 
   useEffect(() => {
@@ -99,10 +72,10 @@ const TheaterItem = ({ title }) => {
         }
       } catch (e) {}
     }; // onMessage
+
     for (const device of devices) {
       switch (device.type) {
         case "lgtv":
-          tvType = "lgtv";
           MQTT.subscribe(`${Config.mqtt.lgtv}/${device.device}/status/power`, onMessage);
           MQTT.subscribe(`${Config.mqtt.lgtv}/${device.device}/status/foregroundApp`, onMessage);
           MQTT.subscribe(`${Config.mqtt.lgtv}/${device.device}/status/launchPoints`, onMessage);
@@ -144,7 +117,35 @@ const TheaterItem = ({ title }) => {
         }
       }
     };
-  }, [currentActivity, power, launchPoints, avrInput, tvInput]);
+  }, []);
+
+  const findTheater = () => {
+    for (const t of Config.theaters) {
+      if (t.title === title) {
+        return t;
+      }
+    }
+    return null;
+  };
+
+  const def = findTheater();
+  if (!def) {
+    return <div>Config.js error: Theater {title} not found</div>;
+  }
+
+  const devices = def.devices || [],
+    deviceMap = {};
+
+  for (const device of devices) {
+    deviceMap[device.type] = device;
+  }
+
+  const activities = def.activities || [],
+    activitiesMap = {};
+
+  for (const activity of activities) {
+    activitiesMap[activity.name] = activities;
+  }
 
   const renderCurrentDevice = () => {
     if (currentDevice.current === "TiVo") {

--- a/src/Phone/Theater/Devices/Harmony.js
+++ b/src/Phone/Theater/Devices/Harmony.js
@@ -75,7 +75,8 @@ const HarmonyRemoteControl = ({ hub }) => {
         MQTT.unsubscribe(status_topic + topic, handleStateChange);
       }
     };
-  }, [handleStateChange, status_topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // render
   if (activities && startingActivity) {

--- a/src/common/ThermostatButton.js
+++ b/src/common/ThermostatButton.js
@@ -52,7 +52,8 @@ const ThermostatButton = ({ thermostat }) => {
       MQTT.unsubscribe(thermostat_status_topic + "target_temperature_f", handleStateChange);
       MQTT.unsubscribe(thermostat_status_topic + "hvac_state", handleStateChange);
     };
-  }, [thermostat_status_topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleClickDown = () => {
     const target_temperature = targetTemperature - 1;

--- a/src/common/hooks/useAutelis.js
+++ b/src/common/hooks/useAutelis.js
@@ -134,7 +134,8 @@ const useAutelis = () => {
         MQTT.unsubscribe(status_topic + forward[key], handleStateChange);
       }
     };
-  }, [forward, handleStateChange, status_topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [, d] = useReducer(reducer.current);
   return {

--- a/src/common/hooks/useBravia.js
+++ b/src/common/hooks/useBravia.js
@@ -180,7 +180,8 @@ const useBravia = config => {
       MQTT.unsubscribe(status_topic + "power", handlePower);
       MQTT.unsubscribe(status_topic + "volume", handleVolume);
     };
-  }, [status_topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [, d] = useReducer(reducer);
   return {

--- a/src/common/hooks/useDenon.js
+++ b/src/common/hooks/useDenon.js
@@ -94,7 +94,8 @@ const useDenon = config => {
       MQTT.unsubscribe(`${Config.mqtt.denon}/${config.device}/status/CVC`, handleMessage);
       MQTT.unsubscribe(`${Config.mqtt.denon}/${config.device}/status/DC`, handleMessage);
     };
-  }, [config.device]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     dispatch: d,

--- a/src/common/hooks/useLGTV.js
+++ b/src/common/hooks/useLGTV.js
@@ -107,7 +107,8 @@ const useLGTV = config => {
     const title = launchPoints[foregroundApp.appId].title;
     const lp = title || "unknown";
     setInput(power ? lp.replace(/\s+/, "").toLowerCase() : "OFF");
-  }, [launchPoints, foregroundApp, power]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     MQTT.subscribe(`lgtv/${hostname}/status/power`, handlePower);

--- a/src/common/hooks/useTVGuide.js
+++ b/src/common/hooks/useTVGuide.js
@@ -16,7 +16,8 @@ const useTVGuide = guide => {
     return () => {
       MQTT.unsubscribe(`${Config.mqtt.tvguide}/${guide}/status/channels`, handleChannels);
     };
-  }, [guide]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     channels: channels,

--- a/src/common/hooks/useTiVo.js
+++ b/src/common/hooks/useTiVo.js
@@ -87,7 +87,8 @@ const useTiVo = config => {
       MQTT.unsubscribe(`${topic}mode`, handleMessage);
       MQTT.unsubscribe(`${topic}reason`, handleMessage);
     };
-  }, [topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [, d] = useReducer(reducer.current);
   return {

--- a/src/common/hooks/useWeather.js
+++ b/src/common/hooks/useWeather.js
@@ -33,7 +33,8 @@ const useWeather = zip => {
       MQTT.unsubscribe(status_topic + "now", handleNowChange);
       MQTT.unsubscribe(status_topic + "display_city", handleCityChange);
     };
-  }, [status_topic, zip]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     now: now || {},

--- a/src/lib/MQTTScript.js
+++ b/src/lib/MQTTScript.js
@@ -44,7 +44,8 @@ const MQTTScript = ({ script, onComplete }) => {
         setTimer(null);
       }
     };
-  }, [scriptCopy, currentCommand, timer, script]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!script) {
     return null;


### PR DESCRIPTION
The useEffect() second argument/array is automatically filled in by eslint --fix with values that badly break the app.  Running on an iPad Pro with fast CPU, the subscribe/unsubscribe (mount/unmount) storm that is caused makes the UI unresponsive.

it is probably bad coding practice on my part to compute values over and over since these are const and the eslint plugin breaks the code.

I added // ignore lines to fix this temporarily.
